### PR TITLE
Correct Elasticsearch.js sourceUrl as it was previously wrong

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,14 +13,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>elasticsearch-js</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>elasticsearch-js</name>
     <description>WebJar for Elasticsearch.js</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <elasticsearch.version>1.0.3</elasticsearch.version>
+        <elasticsearch.version>1.1.0</elasticsearch.version>
         <elasticsearch.sourceUrl>https://download.elasticsearch.org/elasticsearch/elasticsearch-js</elasticsearch.sourceUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${elasticsearch.version}</destDir>
     </properties>


### PR DESCRIPTION
This PR comes to correct an error in Elasticsearch.js sourceUrl. 
Note: Both tags previously created in my repository for Elasticsearch.js version 1.0.3 and 1.1.0 are now corrected.
