### PR TITLE
Move elasticsearch-js to use webjars-parent-maven instead of oss-parent...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
+        <groupId>org.webjars</groupId>
+        <artifactId>webjars-parent-maven</artifactId>
+        <version>1</version>
     </parent>
 
     <packaging>jar</packaging>
-    <groupId>org.webjars</groupId>
     <artifactId>elasticsearch-js</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <name>elasticsearch-js</name>
     <description>WebJar for Elasticsearch.js</description>
     <url>http://webjars.org</url>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <elasticsearch.version>2.2.0</elasticsearch.version>
-        <elasticsearch.sourceUrl>https://download.elasticsearch.org/elasticsearch/elasticsearch-js</elasticsearch.sourceUrl>
+        <elasticsearch.version>2.3.0</elasticsearch.version>
+        <elasticsearch.sourceUrl>https://download.elasticsearch.org/elasticsearch/elasticsearch-js
+        </elasticsearch.sourceUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${elasticsearch.version}</destDir>
     </properties>
 
@@ -51,11 +51,12 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>wagon-maven-plugin</artifactId>
-                <version>1.0-beta-4</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>
-                        <goals><goal>download-single</goal></goals>
+                        <goals>
+                            <goal>download-single</goal>
+                        </goals>
                         <configuration>
                             <url>${elasticsearch.sourceUrl}</url>
                             <fromFile>elasticsearch-js-${elasticsearch.version}.zip</fromFile>
@@ -67,41 +68,25 @@
 
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>
-                        <goals><goal>run</goal></goals>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                         <configuration>
                             <target>
-                                <echo message="unzip archive" />
-                                <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
-                                <echo message="moving resources" />
+                                <echo message="unzip archive"/>
+                                <unzip src="${project.build.directory}/${project.artifactId}.zip"
+                                       dest="${project.build.directory}"/>
+                                <echo message="moving resources"/>
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/elasticsearch-js" />
+                                    <fileset dir="${project.build.directory}/elasticsearch-js"/>
                                 </move>
                             </target>
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.5.1</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>sonatype-nexus-staging</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
...and bump elasticsearch-js version to 2.3.0.

This pull request is related to issue: https://github.com/webjars/webjars/issues/510.
I suggest to give it a try with this real webjar first.
